### PR TITLE
Qt::UniqueConnection for burst modes data

### DIFF
--- a/JAERO/aerol.h
+++ b/JAERO/aerol.h
@@ -437,41 +437,8 @@ public:
 private:
 
     QVector<int> pre_state;
-   //  QVector<int> state;
     int position;
 };
-
-
-
-/*
-class AeroLScrambler
-{
-public:
-    AeroLScrambler()
-    {
-        reset();
-    }
-    void reset()
-    {
-        int tmp[]={1,1,0,1,0,0,1,0,1,0,1,1,0,0,1,-1};
-        state.clear();
-        for(int i=0;tmp[i]>=0;i++)state.push_back(tmp[i]);
-    }
-    void update(QVector<int> &data)
-    {
-        for(int j=0;j<data.size();j++)
-        {
-            int val0=state.at(0)^state.at(14);
-            data[j] = data.at(j)^val0;
-            for(int i=state.size()-1;i>0;i--)state[i]=state.at(i-1);
-            state[0] =val0;
-        }
-    }
-private:
-    QVector<int> state;
-};
-
-*/
 
 class PuncturedCode
 {

--- a/JAERO/aerol.h
+++ b/JAERO/aerol.h
@@ -437,8 +437,41 @@ public:
 private:
 
     QVector<int> pre_state;
+   //  QVector<int> state;
     int position;
 };
+
+
+
+/*
+class AeroLScrambler
+{
+public:
+    AeroLScrambler()
+    {
+        reset();
+    }
+    void reset()
+    {
+        int tmp[]={1,1,0,1,0,0,1,0,1,0,1,1,0,0,1,-1};
+        state.clear();
+        for(int i=0;tmp[i]>=0;i++)state.push_back(tmp[i]);
+    }
+    void update(QVector<int> &data)
+    {
+        for(int j=0;j<data.size();j++)
+        {
+            int val0=state.at(0)^state.at(14);
+            data[j] = data.at(j)^val0;
+            for(int i=state.size()-1;i>0;i--)state[i]=state.at(i-1);
+            state[0] =val0;
+        }
+    }
+private:
+    QVector<int> state;
+};
+
+*/
 
 class PuncturedCode
 {

--- a/JAERO/mainwindow.cpp
+++ b/JAERO/mainwindow.cpp
@@ -472,7 +472,7 @@ void MainWindow::selectdemodulatorconnections(DemodType demodtype)
         connect(ui->spectrumdisplay,   SIGNAL(CenterFreqChanged(double)),                          audioburstoqpskdemodulator,SLOT(CenterFreqChangedSlot(double)));
         connect(audioburstoqpskdemodulator, SIGNAL(BitRateChanged(double,bool)),                   aerol,SLOT(setSettings(double,bool)));
         connect(audioburstoqpskdemodulator, SIGNAL(SignalStatus(bool)),aerol,SLOT(SignalStatusSlot(bool)));
-        connect(zmq_audio_receiver, SIGNAL(recAudio(const QByteArray&,quint32)), audioburstoqpskdemodulator, SLOT(dataReceived(QByteArray,quint32)));
+        connect(zmq_audio_receiver, SIGNAL(recAudio(const QByteArray&,quint32)), audioburstoqpskdemodulator, SLOT(dataReceived(QByteArray,quint32)), Qt::UniqueConnection);
 
         //burstdemod demod2
         connect(audioburstoqpskdemodulator->demod2, SIGNAL(Plottables(double,double,double)),              this,SLOT(PlottablesSlot(double,double,double)));
@@ -564,7 +564,7 @@ void MainWindow::selectdemodulatorconnections(DemodType demodtype)
         connect(ui->spectrumdisplay, SIGNAL(CenterFreqChanged(double)),                     audioburstmskdemodulator,SLOT(CenterFreqChangedSlot(double)));
         connect(audioburstmskdemodulator, SIGNAL(BitRateChanged(double,bool)),                   aerol,SLOT(setSettings(double,bool)));
         connect(audioburstmskdemodulator, SIGNAL(SignalStatus(bool)),                           aerol,SLOT(SignalStatusSlot(bool)));
-        connect(zmq_audio_receiver, SIGNAL(recAudio(const QByteArray&,quint32)), audioburstmskdemodulator, SLOT(dataReceived(QByteArray,quint32)));
+        connect(zmq_audio_receiver, SIGNAL(recAudio(const QByteArray&,quint32)), audioburstmskdemodulator, SLOT(dataReceived(QByteArray,quint32)), Qt::UniqueConnection);
 
         break;
     }

--- a/JAERO/mainwindow.cpp
+++ b/JAERO/mainwindow.cpp
@@ -472,7 +472,7 @@ void MainWindow::selectdemodulatorconnections(DemodType demodtype)
         connect(ui->spectrumdisplay,   SIGNAL(CenterFreqChanged(double)),                          audioburstoqpskdemodulator,SLOT(CenterFreqChangedSlot(double)));
         connect(audioburstoqpskdemodulator, SIGNAL(BitRateChanged(double,bool)),                   aerol,SLOT(setSettings(double,bool)));
         connect(audioburstoqpskdemodulator, SIGNAL(SignalStatus(bool)),aerol,SLOT(SignalStatusSlot(bool)));
-        connect(zmq_audio_receiver, SIGNAL(recAudio(const QByteArray&,quint32)), audioburstoqpskdemodulator, SLOT(dataReceived(QByteArray,quint32)), Qt::UniqueConnection);
+        connect(zmq_audio_receiver, SIGNAL(recAudio(const QByteArray&,quint32)), audioburstoqpskdemodulator, SLOT(dataReceived(QByteArray,quint32)));
 
         //burstdemod demod2
         connect(audioburstoqpskdemodulator->demod2, SIGNAL(Plottables(double,double,double)),              this,SLOT(PlottablesSlot(double,double,double)));
@@ -564,7 +564,7 @@ void MainWindow::selectdemodulatorconnections(DemodType demodtype)
         connect(ui->spectrumdisplay, SIGNAL(CenterFreqChanged(double)),                     audioburstmskdemodulator,SLOT(CenterFreqChangedSlot(double)));
         connect(audioburstmskdemodulator, SIGNAL(BitRateChanged(double,bool)),                   aerol,SLOT(setSettings(double,bool)));
         connect(audioburstmskdemodulator, SIGNAL(SignalStatus(bool)),                           aerol,SLOT(SignalStatusSlot(bool)));
-        connect(zmq_audio_receiver, SIGNAL(recAudio(const QByteArray&,quint32)), audioburstmskdemodulator, SLOT(dataReceived(QByteArray,quint32)), Qt::UniqueConnection);
+        connect(zmq_audio_receiver, SIGNAL(recAudio(const QByteArray&,quint32)), audioburstmskdemodulator, SLOT(dataReceived(QByteArray,quint32)));
 
         break;
     }


### PR DESCRIPTION
Hi Jonti,

Hope you are doing well. Doing some C band testing and noticed that the burst modes get duplicated data off the ZMQ receiver. As is the case for the non-burst modes, creating the connections with Qt::UniqueConnection fixes the issue. 

I accidentally commited some other stuff in aerol.h which I then reverted, not sure what you are seeing but the changes is only the 2 lines in the mainwindow.cpp

Best Regards

Jeroen