### PR TITLE
Do not abuse audio backend (pulseaudio) with single sample writes

### DIFF
--- a/JAERO/audiooutdevice.cpp
+++ b/JAERO/audiooutdevice.cpp
@@ -94,7 +94,15 @@ qint64 AudioOutDevice::readData(char *data, qint64 maxlen)
     if(numofsamples<1)
     {
         circ_buffer[circ_buffer_tail]=((double)circ_buffer[circ_buffer_tail])*0.75;
-        *ptr=circ_buffer[circ_buffer_tail];
+        if(maxlen > 2000)
+        {
+            for(int i=0;i<2000;i++)
+            {
+                *ptr=circ_buffer[circ_buffer_tail];
+                ptr++;
+            }
+            return 2000;
+        }
         return sizeof(qint16);
     }
 


### PR DESCRIPTION
It look like `AudioOutDevice::readData` does bad things to audio backend if the circular buffer is full. It writes 1 sample per call, increasing CPU consumption and making pulseaudio (in case, it is used) have hard times trying to synchronize all streams if there are multiple instances of JAERO running.
Writing more dummy samples (2000 works well) at once reduces load on both pulseaudio and JAERO making it easier to run multiple instances and prevents pulseaudio crashes.
Closes https://github.com/jontio/JAERO/issues/77
Pulseaudio CPU time consumption master:
![JAERO-pulse-cpu-usage](https://user-images.githubusercontent.com/17007837/188339479-ee776f06-129b-481d-a1ad-9b9ce511ee48.png)
This branch:
![JAERO-fixed-pulseaudio](https://user-images.githubusercontent.com/17007837/188339485-d3435a7b-46b6-4af2-8204-9d73f14632a0.png)
