### PR TITLE
Jeroen/arincparse

### DIFF
--- a/JAERO/arincparse.cpp
+++ b/JAERO/arincparse.cpp
@@ -65,7 +65,20 @@ void ArincParse::try_acars_apps(ACARSItem &acarsitem, la_msg_dir msg_dir)
     }
     else
     {
+        // look for a sublabel and if found strip the sublabel(s) from the message before decoding
         ba = acarsitem.message.toLatin1();
+        char sublabel[3];
+        char mfi[3];
+        int offset = la_acars_extract_sublabel_and_mfi(acarsitem.LABEL.data(), msg_dir, ba.data(),strlen( ba.data()), sublabel, mfi);
+
+        if(offset > 0)
+        {
+            ba = "/" + acarsitem.message.right(acarsitem.message.length()-offset).replace("- #" + QString(sublabel),"").trimmed().toLatin1();
+        }
+        else
+        {
+            ba = acarsitem.message.toLatin1();
+        }
     }
     if(ba.isEmpty())return;
 

--- a/ci-windows-build.sh
+++ b/ci-windows-build.sh
@@ -162,8 +162,8 @@ cp /mingw64/bin/zlib1.dll $PWD
 cp /mingw64/bin/qcustomplot2.dll $PWD
 cp /mingw64/bin/Qt5PrintSupport.dll $PWD
 cp /mingw64/bin/libdouble-conversion.dll $PWD
-cp /mingw64/bin/libicuin72.dll $PWD
-cp /mingw64/bin/libicuuc72.dll $PWD
+cp /mingw64/bin/libicuin74.dll $PWD
+cp /mingw64/bin/libicuuc74.dll $PWD
 cp /mingw64/bin/libpcre2-16-0.dll $PWD
 cp /mingw64/bin/libpcre2-8-0.dll $PWD
 cp /mingw64/bin/libzstd.dll $PWD
@@ -172,7 +172,7 @@ cp /mingw64/bin/libpng16-16.dll $PWD
 cp /mingw64/bin/libfreetype-6.dll $PWD
 cp /mingw64/bin/libgraphite2.dll $PWD
 cp /mingw64/bin/libglib-2.0-0.dll $PWD
-cp /mingw64/bin/libicudt72.dll $PWD
+cp /mingw64/bin/libicudt74.dll $PWD
 cp /mingw64/bin/libbz2-1.dll $PWD
 cp /mingw64/bin/libbrotlidec.dll $PWD
 cp /mingw64/bin/libintl-8.dll $PWD
@@ -180,7 +180,7 @@ cp /mingw64/bin/libpcre-1.dll $PWD
 cp /mingw64/bin/libbrotlicommon.dll $PWD
 cp /mingw64/bin/libiconv-2.dll $PWD
 cp /mingw64/bin/libzmq.dll $PWD
-cp /mingw64/bin/libsodium-23.dll $PWD
+cp /mingw64/bin/libsodium-26.dll $PWD
 cp /mingw64/bin/libmd4c.dll $PWD
 cp /mingw64/bin/libjpeg-8.dll $PWD
 #7za.exe not needed anymore


### PR DESCRIPTION
Hi Jonti,

Seems that currently JAERO is not getting decodes from some acars messages because of changes in the libacars interface between versions 1.x and 2.x. Messages likes these:

- #MD/AA SOUCAYA.AT1.21110A21DFA7AA48A1D5A54A2CEA8820D48682ACE93510458F52A2C993E7449F396438B3AA45A4A189

Are currently not decoded. The "MD" sublabel needs to be trimmed off both at the front and possibly subsequent occurrances for multipart messages.  I ran it by Tomasz and he suggested using la_acars_extract_sublabel_and_mfi to get the sublabel and offset. 

Also updated some lib version numbers to get the build to succeed.

BR

Jeroen